### PR TITLE
Fix HTML escaping in text replacement for highlighting

### DIFF
--- a/home/utils.py
+++ b/home/utils.py
@@ -53,7 +53,7 @@ def escape_and_replace_in_html(pattern, replacement_func, html_content):
 
         new_text = re.sub(pattern, replacement_func, original_text)
         if new_text != original_text:
-            text_node.replace_with(BeautifulSoup(new_text, PARSER))
+            text_node.replace_with(new_text)
     
     return str(soup)
     
@@ -110,4 +110,5 @@ def get_response(text):
         print(f"Unexpected error: {e}")
         return None
 
+    
     


### PR DESCRIPTION
Changed the replacement logic in escape_and_replace_in_html to directly replace text nodes with strings instead of parsing them again as HTML. This prevents double parsing and potential mangling of HTML entities, improving the reliability of the highlight function.